### PR TITLE
Add `remove` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ glee add *.txt
 # Add a glob pattern itself to the exclude list (escaping the special character)
 glee add \*.txt
 
+# Remove specific files from the exclude list
+glee remove filename1 filename2
+
+# Remove multiple files using a glob pattern
+glee remove *.txt
+
+# Remove a glob pattern itself from the exclude list (escaping the special character)
+glee remove \*.txt
+
 # Display current entries in the exclude list
 glee list
 

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/vpukhanov/glee/pkg/glee"
+)
+
+var removeCmd = &cobra.Command{
+	Use:   "remove [files to unignore]",
+	Short: "Remove entries from git exclude list",
+	Long: `Remove files from the local exclude list, allowing them to be tracked by git again.
+
+You can remove multiple files using glob patterns:
+	glee remove filename*.txt
+		
+To remove a glob pattern itself from the exclude list, escape special characters with a backslash:
+	glee remove filename\*.txt`,
+	Args: cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return glee.RemoveExcludes(args)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(removeCmd)
+}

--- a/pkg/glee/glee.go
+++ b/pkg/glee/glee.go
@@ -35,6 +35,49 @@ func AddExcludes(entries []string) error {
 	return nil
 }
 
+func RemoveExcludes(entries []string) error {
+	_, excludeFile, err := getGitRootAndExcludePath()
+	if err != nil {
+		return err
+	}
+
+	content, err := os.ReadFile(excludeFile)
+	if err != nil {
+		return fmt.Errorf("reading exclude file: %w", err)
+	}
+
+	lines := strings.Split(strings.TrimRight(string(content), "\n"), "\n")
+	var newLines []string
+
+	for _, line := range lines {
+		trimmedLine := strings.TrimSpace(line)
+		if trimmedLine == "" || strings.HasPrefix(trimmedLine, "#") {
+			newLines = append(newLines, line)
+			continue
+		}
+
+		shouldKeep := true
+		for _, entry := range entries {
+			if trimmedLine == entry {
+				shouldKeep = false
+				break
+			}
+		}
+
+		if shouldKeep {
+			newLines = append(newLines, line)
+		}
+	}
+
+	newContent := strings.Join(newLines, "\n") + "\n"
+
+	if err := os.WriteFile(excludeFile, []byte(newContent), 0644); err != nil {
+		return fmt.Errorf("writing updated exclude file: %w", err)
+	}
+
+	return nil
+}
+
 func ListExcludes() error {
 	_, excludeFile, err := getGitRootAndExcludePath()
 	if err != nil {


### PR DESCRIPTION
This PR introduces a new `remove` command, allowing users to remove entries from the .git/info/exclude file. 